### PR TITLE
View class don't find

### DIFF
--- a/src/LaravelMpdf/LaravelMpdfWrapper.php
+++ b/src/LaravelMpdf/LaravelMpdfWrapper.php
@@ -2,8 +2,8 @@
 
 namespace Meneses\LaravelMpdf;
 
-use File;
-use View;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
 
 class LaravelMpdfWrapper {
 


### PR DESCRIPTION
In laravel 5.6 we need to add specified namespace with class to interact with view and files directory of laravel.